### PR TITLE
Add Zcash support

### DIFF
--- a/Engine/Requester.php
+++ b/Engine/Requester.php
@@ -84,7 +84,7 @@ function requester_single($daemon, $endpoint = '', $params = [], $result_in = ''
     // Also it doesn't work with negative numbers, and doesn't process integer arrays (e.g. `[4359895000,2039280]`)
     // TODO: this should be rewritten to support all the aforementioned cases
     if (!isset($_ENV['__IGNORE_REPLACING_NUMBERS_IN_JSON_DECODE']))
-        $output = preg_replace('/("\w+"):([\d\.]+)/', '\\1:"\\2"', $output);
+        $output = preg_replace('/("\w+"):(-?[\d\.]+)/', '\\1:"\\2"', $output);
 
     if (!($output = json_decode($output, associative: true, flags: JSON_BIGINT_AS_STRING)))
     {
@@ -256,7 +256,7 @@ function requester_multi_process($output, $result_in = '', $ignore_errors = fals
     $output_log = (env('DEBUG_REQUESTER_FULL_OUTPUT_ON_EXCEPTION', false)) ? $output : 'scrapped';
 
     if (!isset($_ENV['__IGNORE_REPLACING_NUMBERS_IN_JSON_DECODE']))
-        $output = preg_replace('/("\w+"):([\d\.]+)/', '\\1:"\\2"', $output);
+        $output = preg_replace('/("\w+"):(-?[\d\.]+)/', '\\1:"\\2"', $output);
 
     if (!($output = json_decode($output, associative: true, flags: JSON_BIGINT_AS_STRING)))
     {

--- a/Modules/Common/UTXOTraits.php
+++ b/Modules/Common/UTXOTraits.php
@@ -67,6 +67,7 @@ enum UTXOSpecialFeatures
     case IgnorePubKeyConversion; // Bitcoin Cash node shows P2PK addresses correctly
     case HasAddressPrefixes; // Bitcoin Cash node uses `bitcoincash:` prefix for all standard addresses
     case HasMWEB; // Litecoin Core has some additional MWEB data
+    case HasShieldedPools; // Shielded pool processing in Zcash
 }
 
 // See https://stackoverflow.com/questions/19233053/hashing-from-a-public-key-to-a-bitcoin-address-in-php

--- a/Modules/ZcashMainModule.php
+++ b/Modules/ZcashMainModule.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1); // by nikzh@nikzh.com for 3xpl.com, v.3.0.0
+
+/*  Copyright (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com
+ *  Distributed under the MIT software license, see the accompanying file LICENSE.md  */
+
+/*  This module processes both transparent and shielded transfers. There are three special addresses for the shielded
+ *  pools: `sprout-pool`, `sapling-pool`, `orchard-pool`. If all events for these addresses are summed up, one will get
+ *  the amount of coins in these pools. This module requires the latest Zcash node version. If one was upgrading from
+ *  some previous version, they'd need to use `reindex`.  */
+
+final class ZcashMainModule extends UTXOMainModule implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'zcash';
+        $this->module = 'zcash-main';
+        $this->is_main = true;
+        $this->currency = 'zcash';
+        $this->currency_details = ['name' => 'Zcash', 'symbol' => 'ZEC', 'decimals' => 8, 'description' => null];
+        $this->first_block_date = '2016-10-28';
+
+        // UTXOMainModule
+        $this->extra_features = [UTXOSpecialFeatures::HasShieldedPools];
+        $this->p2pk_prefix1 = '';
+        $this->p2pk_prefix2 = '1CB8';
+    }
+}


### PR DESCRIPTION
This PR adds Zcash support.

This module processes both transparent and shielded transfers. It also introduces three special addresses for the shielded pools: `sprout-pool`, `sapling-pool`, and `orchard-pool`. If one sums up all the events for these addresses, they'd get the amount of coins in the corresponding shielded pool, see:
* https://3xpl.com/zcash/address/sprout-pool
* https://3xpl.com/zcash/address/sapling-pool
* https://3xpl.com/zcash/address/orchard-pool