### PR TITLE
Restored compatibility with the latest Geth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.env
+.idea
+.vscode
+.DS_Store

--- a/Modules/Common/EVMERC1155Module.php
+++ b/Modules/Common/EVMERC1155Module.php
@@ -53,7 +53,8 @@ abstract class EVMERC1155Module extends CoreModule
         // Get logs
 
         $logs_single = requester_single($this->select_node(),
-            params: ['method' => 'eth_getLogs',
+            params: ['jsonrpc'=> '2.0',
+                     'method' => 'eth_getLogs',
                      'params' =>
                          [['blockhash' => $this->block_hash,
                            'topics'    => ['0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62'],
@@ -64,7 +65,7 @@ abstract class EVMERC1155Module extends CoreModule
             result_in: 'result', timeout: $this->timeout); // TransferSingle
 
         $logs_batch = requester_single($this->select_node(),
-            params: ['method' => 'eth_getLogs',
+            params: ['jsonrpc'=> '2.0', 'method' => 'eth_getLogs',
                      'params' =>
                          [['blockhash' => $this->block_hash,
                            'topics'    => ['0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb'],
@@ -164,11 +165,11 @@ abstract class EVMERC1155Module extends CoreModule
             foreach ($currencies_to_process as $currency_id)
             {
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x06fdde03'], 'latest'], 'id' => $this_id++],
+                    params: ['jsonrpc'=> '2.0', 'method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x06fdde03'], 'latest'], 'id' => $this_id++],
                     timeout: $this->timeout); // Name
 
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x95d89b41'], 'latest'], 'id' => $this_id++],
+                    params: ['jsonrpc'=> '2.0', 'method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x95d89b41'], 'latest'], 'id' => $this_id++],
                     timeout: $this->timeout); // Symbol
             }
 

--- a/Modules/Common/EVMERC20Module.php
+++ b/Modules/Common/EVMERC20Module.php
@@ -51,7 +51,8 @@ abstract class EVMERC20Module extends CoreModule
         // Get logs
 
         $logs = requester_single($this->select_node(),
-            params: ['method' => 'eth_getLogs',
+            params: ['jsonrpc'=> '2.0',
+                     'method' => 'eth_getLogs',
                      'params' =>
                          [['blockhash' => $this->block_hash,
                            'topics'    => ['0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'],
@@ -108,15 +109,15 @@ abstract class EVMERC20Module extends CoreModule
             foreach ($currencies_to_process as $currency_id)
             {
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x06fdde03'], 'latest'], 'id' => $this_id++],
+                    params: ['jsonrpc'=> '2.0', 'method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x06fdde03'], 'latest'], 'id' => $this_id++],
                     timeout: $this->timeout); // Name
 
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x95d89b41'], 'latest'], 'id' => $this_id++],
+                    params: ['jsonrpc'=> '2.0', 'method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x95d89b41'], 'latest'], 'id' => $this_id++],
                     timeout: $this->timeout); // Symbol
 
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x313ce567'], 'latest'], 'id' => $this_id++],
+                    params: ['jsonrpc'=> '2.0', 'method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x313ce567'], 'latest'], 'id' => $this_id++],
                     timeout: $this->timeout); // Decimals
             }
 

--- a/Modules/Common/EVMERC721Module.php
+++ b/Modules/Common/EVMERC721Module.php
@@ -53,7 +53,8 @@ abstract class EVMERC721Module extends CoreModule
         // Get logs
 
         $logs = requester_single($this->select_node(),
-            params: ['method' => 'eth_getLogs',
+            params: ['jsonrpc'=> '2.0',
+                     'method' => 'eth_getLogs',
                      'params' =>
                          [['blockhash' => $this->block_hash,
                            'topics'    => ['0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'],
@@ -112,11 +113,11 @@ abstract class EVMERC721Module extends CoreModule
             foreach ($currencies_to_process as $currency_id)
             {
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x06fdde03'], 'latest'], 'id' => $this_id++],
+                    params: ['jsonrpc'=> '2.0', 'method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x06fdde03'], 'latest'], 'id' => $this_id++],
                     timeout: $this->timeout); // Name
 
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x95d89b41'], 'latest'], 'id' => $this_id++],
+                    params: ['jsonrpc'=> '2.0', 'method' => 'eth_call', 'params' => [['to' => $currency_id, 'data' => '0x95d89b41'], 'latest'], 'id' => $this_id++],
                     timeout: $this->timeout); // Symbol
             }
 

--- a/Modules/Common/EVMMainModule.php
+++ b/Modules/Common/EVMMainModule.php
@@ -79,17 +79,19 @@ abstract class EVMMainModule extends CoreModule
                 $multi_curl = [];
 
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_getBlockByNumber',
-                             'params' => [to_0xhex_from_int64($block_id),
+                    params: ['jsonrpc' => "2.0",
+                             'method'  => 'eth_getBlockByNumber',
+                             'params'  => [to_0xhex_from_int64($block_id),
                                           true,
                              ],
-                             'id'     => 0,
+                             'id'      => 0,
                     ], timeout: $this->timeout);
 
                 $multi_curl[] = requester_multi_prepare($this->select_node(),
-                    params: ['method' => 'eth_getBlockReceipts',
-                             'params' => [to_0xhex_from_int64($block_id)],
-                             'id'     => 0,
+                    params: ['jsonrpc' => "2.0",
+                             'method'  => 'eth_getBlockReceipts',
+                             'params'  => [to_0xhex_from_int64($block_id)],
+                             'id'      => 0,
                     ], timeout: $this->timeout);
 
                 $curl_results = requester_multi($multi_curl, limit: envm($this->module, 'REQUESTER_THREADS'), timeout: $this->timeout);
@@ -130,7 +132,7 @@ abstract class EVMMainModule extends CoreModule
             else // geth is slower as we have to do eth_getTransactionReceipt for every transaction separately
             {
                 $r1 = requester_single($this->select_node(),
-                    params: ['method' => 'eth_getBlockByNumber', 'params' => [to_0xhex_from_int64($block_id), true], 'id' => 0],
+                    params: ['jsonrpc'=> '2.0', 'method' => 'eth_getBlockByNumber', 'params' => [to_0xhex_from_int64($block_id), true], 'id' => 0],
                     result_in: 'result', timeout: $this->timeout);
 
                 $block_time = $r1['timestamp'];
@@ -153,7 +155,7 @@ abstract class EVMMainModule extends CoreModule
                 foreach ($r1['transactions'] as $transaction)
                 {
                     $multi_curl[] = requester_multi_prepare($this->select_node(),
-                        params: ['method' => 'eth_getTransactionReceipt', 'params' => [$transaction['hash']], 'id' => $ij++], timeout: $this->timeout);
+                        params: ['jsonrpc'=> '2.0', 'method' => 'eth_getTransactionReceipt', 'params' => [$transaction['hash']], 'id' => $ij++], timeout: $this->timeout);
                 }
 
                 $curl_results = requester_multi($multi_curl, limit: envm($this->module, 'REQUESTER_THREADS'),
@@ -203,7 +205,7 @@ abstract class EVMMainModule extends CoreModule
         else // Mempool processing
         {
             $r = requester_single($this->select_node(),
-                params: ['method' => 'txpool_content', 'id' => 0],
+                params: ['jsonrpc'=> '2.0', 'method' => 'txpool_content', 'id' => 0],
                 result_in: 'result',
                 timeout: $this->timeout);
 
@@ -372,7 +374,7 @@ abstract class EVMMainModule extends CoreModule
 
                 foreach ($uncles as $uncle)
                     $multi_curl[] = requester_multi_prepare($this->select_node(),
-                        params: ['method' => 'eth_getUncleByBlockNumberAndIndex', 'params' => [to_0xhex_from_int64($block_id), to_0xhex_from_int64($ij)],
+                        params: ['jsonrpc'=> '2.0', 'method' => 'eth_getUncleByBlockNumberAndIndex', 'params' => [to_0xhex_from_int64($block_id), to_0xhex_from_int64($ij)],
                                  'id' => $ij++], timeout: $this->timeout);
 
                 $curl_results = requester_multi($multi_curl, limit: envm($this->module, 'REQUESTER_THREADS'), timeout: $this->timeout);
@@ -527,7 +529,7 @@ abstract class EVMMainModule extends CoreModule
             return '0';
 
         return to_int256_from_0xhex(requester_single($this->select_node(),
-            params: ['method' => 'eth_getBalance', 'params' => [$address, 'latest'], 'id' => 0],
+            params: ['jsonrpc'=> '2.0', 'method' => 'eth_getBalance', 'params' => [$address, 'latest'], 'id' => 0],
             result_in: 'result', timeout: $this->timeout));
     }
 }

--- a/Modules/Common/EVMTraceModule.php
+++ b/Modules/Common/EVMTraceModule.php
@@ -55,7 +55,7 @@ abstract class EVMTraceModule extends CoreModule
         }
 
         $trace = requester_single($this->select_node(),
-            params: ['method' => 'trace_block', 'params' => [to_0xhex_from_int64($block_id)], 'id' => 0],
+            params: ['jsonrpc'=> '2.0', 'method' => 'trace_block', 'params' => [to_0xhex_from_int64($block_id)], 'id' => 0],
             result_in: 'result', timeout: $this->timeout);
 
         $events = [];

--- a/Modules/Common/EVMTraits.php
+++ b/Modules/Common/EVMTraits.php
@@ -33,7 +33,7 @@ trait EVMTraits
     public function inquire_latest_block()
     {
         return to_int64_from_0xhex(requester_single($this->select_node(),
-            params: ['method' => 'eth_blockNumber', 'id' => 0], result_in: 'result', timeout: $this->timeout));
+            params: ['jsonrpc'=> '2.0', 'method' => 'eth_blockNumber', 'id' => 0], result_in: 'result', timeout: $this->timeout));
     }
 
     public function ensure_block($block_id, $break_on_first = false)
@@ -48,11 +48,11 @@ trait EVMTraits
 
         if ($this->evm_implementation === EVMImplementation::Erigon)
         {
-            $params = ['method' => 'erigon_getHeaderByNumber', 'params' => [to_0xhex_from_int64($block_id)], 'id' => 0];
+            $params = ['jsonrpc'=> '2.0', 'method' => 'erigon_getHeaderByNumber', 'params' => [to_0xhex_from_int64($block_id)], 'id' => 0];
         }
         else // geth
         {
-            $params = ['method' => 'eth_getBlockByNumber', 'params' => [to_0xhex_from_int64($block_id), false], 'id' => 0];
+            $params = ['jsonrpc'=> '2.0', 'method' => 'eth_getBlockByNumber', 'params' => [to_0xhex_from_int64($block_id), false], 'id' => 0];
         }
 
         $from_nodes = $this->fast_nodes ?? $this->nodes;


### PR DESCRIPTION
Ethereum modules are no longer compatible with latest go-ethereum (`geth 1.11.x`).
As mentioned in `geth 1.11.0` release notes: `Geth's JSON-RPC server has become more strict; the JSON-RPC spec requires the version field to be exactly "jsonrpc": "2.0". This is now verified by the server -- a change which is not backwards-compatible with non-conforming client implementations.`