### PR TITLE
Add Arbitrum One support (5 modules)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,61 @@ MODULE_ethereum-erc-1155_NODES[]=http://login:password@127.0.0.2:1234/
 MODULE_ethereum-erc-1155_REQUESTER_TIMEOUT=60
 MODULE_ethereum-erc-1155_REQUESTER_THREADS=12
 
+######################
+## Main Arbitrum One Module
+######################
+
+MODULES[]=arbitrum-one-main
+MODULE_arbitrum-one-main_CLASS=ArbitrumOneMainModule
+MODULE_arbitrum-one-main_NODES[]=http://login:password@127.0.0.1:1234/
+MODULE_arbitrum-one-main_NODES[]=http://login:password@127.0.0.2:1234/
+MODULE_arbitrum-one-main_REQUESTER_TIMEOUT=60
+MODULE_arbitrum-one-main_REQUESTER_THREADS=12
+
+#######################
+## Trace Arbitrum One Module
+#######################
+
+MODULES[]=arbitrum-one-trace
+MODULE_arbitrum-one-trace_CLASS=ArbitrumOneTraceModule
+MODULE_arbitrum-one-trace_NODES[]=http://login:password@127.0.0.1:1234/
+MODULE_arbitrum-one-trace_NODES[]=http://login:password@127.0.0.2:1234/
+MODULE_arbitrum-one-trace_REQUESTER_TIMEOUT=60
+MODULE_arbitrum-one-trace_REQUESTER_THREADS=12
+
+########################
+## ERC-20 Arbitrum One Module
+########################
+
+MODULES[]=arbitrum-one-erc-20
+MODULE_arbitrum-one-erc-20_CLASS=ArbitrumOneERC20Module
+MODULE_arbitrum-one-erc-20_NODES[]=http://login:password@127.0.0.1:1234/
+MODULE_arbitrum-one-erc-20_NODES[]=http://login:password@127.0.0.2:1234/
+MODULE_arbitrum-one-erc-20_REQUESTER_TIMEOUT=60
+MODULE_arbitrum-one-erc-20_REQUESTER_THREADS=12
+
+#########################
+## ERC-721 Arbitrum One Module
+#########################
+
+MODULES[]=arbitrum-one-erc-721
+MODULE_arbitrum-one-erc-721_CLASS=ArbitrumOneERC721Module
+MODULE_arbitrum-one-erc-721_NODES[]=http://login:password@127.0.0.1:1234/
+MODULE_arbitrum-one-erc-721_NODES[]=http://login:password@127.0.0.2:1234/
+MODULE_arbitrum-one-erc-721_REQUESTER_TIMEOUT=60
+MODULE_arbitrum-one-erc-721_REQUESTER_THREADS=12
+
+##########################
+## ERC-1155 Arbitrum One Module
+##########################
+
+MODULES[]=arbitrum-one-erc-1155
+MODULE_arbitrum-one-erc-1155_CLASS=ArbitrumOneERC1155Module
+MODULE_arbitrum-one-erc-1155_NODES[]=http://login:password@127.0.0.1:1234/
+MODULE_arbitrum-one-erc-1155_NODES[]=http://login:password@127.0.0.2:1234/
+MODULE_arbitrum-one-erc-1155_REQUESTER_TIMEOUT=60
+MODULE_arbitrum-one-erc-1155_REQUESTER_THREADS=12
+
 ###########################
 ## Main Bitcoin Сash Module
 ###########################

--- a/Modules/ArbitrumOneERC1155Module.php
+++ b/Modules/ArbitrumOneERC1155Module.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+/*  Copyright (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com
+ *  Distributed under the MIT software license, see the accompanying file LICENSE.md  */
+
+/*  This module processes ERC-1155 MT transfers in Arbitrum. It requires a geth node to run.  */
+
+final class ArbitrumOneERC1155Module extends EVMERC1155Module implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'arbitrum-one';
+        $this->module = 'arbitrum-one-erc-1155';
+        $this->is_main = false;
+        $this->first_block_date = '2021-05-28';
+        $this->first_block_id = 0;
+    }
+}

--- a/Modules/ArbitrumOneERC20Module.php
+++ b/Modules/ArbitrumOneERC20Module.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+/*  Copyright (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com
+ *  Distributed under the MIT software license, see the accompanying file LICENSE.md  */
+
+/*  This module processes ERC-20 token transfers in Arbitrum. It requires a geth node to run.  */
+
+final class ArbitrumOneERC20Module extends EVMERC20Module implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'arbitrum-one';
+        $this->module = 'arbitrum-one-erc-20';
+        $this->is_main = false;
+        $this->first_block_date = '2021-05-28';
+        $this->first_block_id = 0;
+    }
+}

--- a/Modules/ArbitrumOneERC721Module.php
+++ b/Modules/ArbitrumOneERC721Module.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+/*  Copyright (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com
+ *  Distributed under the MIT software license, see the accompanying file LICENSE.md  */
+
+/*  This module processes ERC-721 NFT transfers in Arbitrum. It requires a geth node to run.  */
+
+final class ArbitrumOneERC721Module extends EVMERC721Module implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'arbitrum-one';
+        $this->module = 'arbitrum-one-erc-721';
+        $this->is_main = false;
+        $this->first_block_date = '2021-05-28';
+        $this->first_block_id = 0;
+    }
+}

--- a/Modules/ArbitrumOneMainModule.php
+++ b/Modules/ArbitrumOneMainModule.php
@@ -21,6 +21,7 @@ final class ArbitrumOneMainModule extends EVMMainModule implements Module
 
         // EVMMainModule
         $this->evm_implementation = EVMImplementation::geth;
+        $this->extra_features = [EVMSpecialFeatures::AllowEmptyRecipient];
         $this->reward_function = function($block_id)
         {
             return '0';

--- a/Modules/ArbitrumOneMainModule.php
+++ b/Modules/ArbitrumOneMainModule.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+/*  Copyright (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com
+ *  Distributed under the MIT software license, see the accompanying file LICENSE.md  */
+
+/*  This is the main Arbitrum One module. It requires a geth node to run.  */
+
+final class ArbitrumOneMainModule extends EVMMainModule implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'arbitrum-one';
+        $this->module = 'arbitrum-one-main';
+        $this->is_main = true;
+        $this->first_block_date = '2021-05-28';
+        $this->first_block_id = 0;
+        $this->currency = 'ethereum';
+        $this->currency_details = ['name' => 'Ethereum', 'symbol' => 'ETH', 'decimals' => 18, 'description' => null];
+
+        // EVMMainModule
+        $this->evm_implementation = EVMImplementation::geth;
+        $this->reward_function = function($block_id)
+        {
+            return '0';
+        };
+    }
+}

--- a/Modules/ArbitrumOneTraceModule.php
+++ b/Modules/ArbitrumOneTraceModule.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+/*  Copyright (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com
+ *  Distributed under the MIT software license, see the accompanying file LICENSE.md  */
+
+/*  This is the Arbitrum One trace module. It requires a geth node to run with new blocks, and a legacy ("classic") geth node
+ *  to populate the database with blocks up to #22207816.  */
+
+final class ArbitrumOneTraceModule extends EVMTraceModule implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'arbitrum-one';
+        $this->module = 'arbitrum-one-trace';
+        $this->complements = 'arbitrum-one-main';
+        $this->is_main = false;
+        $this->first_block_date = '2021-05-28';
+        $this->first_block_id = 0;
+
+        // EVMTraceModule
+        $this->evm_implementation = EVMImplementation::geth;
+    }
+}

--- a/Modules/Common/EVMMainModule.php
+++ b/Modules/Common/EVMMainModule.php
@@ -359,9 +359,14 @@ abstract class EVMMainModule extends CoreModule
                 }
             }
 
+            if (in_array(EVMSpecialFeatures::AllowEmptyRecipient, $this->extra_features))
+                $recipient = $transaction['to'] ?? $transaction['contractAddress'] ?? '0x00';
+            else
+                $recipient = $transaction['to'] ?? $transaction['contractAddress'] ?? throw new DeveloperError('No address');
+
             $events[] = [
                 'transaction' => $transaction_hash,
-                'address' => $transaction['to'] ?? $transaction['contractAddress'] ?? '0x00',
+                'address' => $recipient,
                 'sort_in_block' => $ijk++,
                 'sort_in_transaction' => 5,
                 'effect' => to_int256_from_0xhex($transaction['value']),

--- a/Modules/Common/EVMMainModule.php
+++ b/Modules/Common/EVMMainModule.php
@@ -361,7 +361,7 @@ abstract class EVMMainModule extends CoreModule
 
             $events[] = [
                 'transaction' => $transaction_hash,
-                'address' => $transaction['to'] ?? $transaction['contractAddress'] ?? throw new DeveloperError('No address'),
+                'address' => $transaction['to'] ?? $transaction['contractAddress'] ?? '0x00',
                 'sort_in_block' => $ijk++,
                 'sort_in_transaction' => 5,
                 'effect' => to_int256_from_0xhex($transaction['value']),

--- a/Modules/Common/EVMTraceModule.php
+++ b/Modules/Common/EVMTraceModule.php
@@ -4,7 +4,7 @@
  *  Copyright (c) 2023 3xpl developers, 3@3xpl.com
  *  Distributed under the MIT software license, see the accompanying file LICENSE.md  */
 
-/*  This module processes "internal" EVM transactions (this requires tracing). Only Erigon is supported.  */
+/*  This module processes "internal" EVM transactions (this requires tracing). Both Erigon and geth are supported.  */
 
 abstract class EVMTraceModule extends CoreModule
 {
@@ -49,128 +49,210 @@ abstract class EVMTraceModule extends CoreModule
 
     final public function pre_process_block($block_id)
     {
-        if ($this->evm_implementation !== EVMImplementation::Erigon)
+        if ($this->evm_implementation === EVMImplementation::geth)
         {
-            throw new DeveloperError('Only Erigon is currently supported for this module');
+            // We have to make two requests: `eth_getBlockByNumber` just to get transaction hashes, and
+            // `debug_traceBlockByNumber` to get the actual traces. That's because `callTracer` doesn't
+            // yield transaction hashed. Theoretically, it's faster to come up with a custom tracer
+            // for this task.
+
+            $multi_curl = [];
+
+            $multi_curl[] = requester_multi_prepare($this->select_node(),
+                params: ['method'  => 'eth_getBlockByNumber',
+                         'params'  => [to_0xhex_from_int64($block_id), false],
+                         'id'      => 0,
+                         'jsonrpc' => '2.0',
+                ], timeout: $this->timeout);
+
+            $multi_curl[] = requester_multi_prepare($this->select_node(),
+                params: ['method'  => 'debug_traceBlockByNumber',
+                         'params'  => [to_0xhex_from_int64($block_id), ['tracer' => 'callTracer']],
+                         'id'      => 1,
+                         'jsonrpc' => '2.0',
+                ], timeout: $this->timeout);
+
+            $curl_results = requester_multi($multi_curl,
+                limit: envm($this->module, 'REQUESTER_THREADS'),
+                timeout: $this->timeout);
+
+            $curl_results_prepared = [];
+
+            foreach ($curl_results as $curl_result)
+            {
+                $curl_results_prepared[] = requester_multi_process($curl_result);
+            }
+
+            reorder_by_id($curl_results_prepared);
+
+            //
+
+            $transaction_hashes = $curl_results_prepared[0]['result']['transactions'];
+
+            if (count($curl_results_prepared[0]['result']['transactions']) !== count($curl_results_prepared[1]['result']))
+                throw new ModuleError('Transaction count mismatch');
+
+            $events = [];
+            $sort_key = 0;
+            $this_i = 0;
+
+            foreach ($curl_results_prepared[1]['result'] as $this_trace)
+            {
+                $this_transaction_hash = $transaction_hashes[$this_i++];
+
+                if (!isset($this_trace['result']['calls']))
+                    continue; // No internal txs
+
+                if (isset($this_trace['result']['error']))
+                    continue; // Root failed
+
+                $this_calls = [];
+
+                evm_trace($this_trace['result']['calls'], $this_calls);
+
+                foreach ($this_calls as $this_call)
+                {
+                    $events[] = [
+                        'transaction' => $this_transaction_hash,
+                        'address' => $this_call['from'],
+                        'sort_key' => $sort_key++,
+                        'effect' => '-' . $this_call['value'],
+                        'extra' => $this_call['type'],
+                    ];
+
+                    $events[] = [
+                        'transaction' => $this_transaction_hash,
+                        'address' => $this_call['to'],
+                        'sort_key' => $sort_key++,
+                        'effect' => $this_call['value'],
+                        'extra' => $this_call['type'],
+                    ];
+                }
+            }
         }
-
-        $trace = requester_single($this->select_node(),
-            params: ['jsonrpc'=> '2.0', 'method' => 'trace_block', 'params' => [to_0xhex_from_int64($block_id)], 'id' => 0],
-            result_in: 'result', timeout: $this->timeout);
-
-        $events = [];
-
-        $current_transaction = '';
-        $sort_key = 0;
-
-        foreach ($trace as $bit)
+        else//if ($this->evm_implementation === EVMImplementation::Erigon)
         {
-            // We don't need block reward data as this is already processed by the main module
-            if (!isset($bit['transactionHash']) && ($bit['type'] === 'reward'))
+            $trace = requester_single($this->select_node(),
+                params: ['jsonrpc' => '2.0',
+                         'method' => 'trace_block',
+                         'params' => [to_0xhex_from_int64($block_id)],
+                         'id' => 0],
+                result_in: 'result', timeout: $this->timeout);
+
+            $events = [];
+
+            $current_transaction = '';
+            $sort_key = 0;
+
+            foreach ($trace as $bit)
             {
-                continue;
-            }
-
-            // New transaction is being processed
-            if ($bit['transactionHash'] !== $current_transaction)
-            {
-                // We don't need the root call as it is already processed by the main module
-                $current_transaction = $bit['transactionHash'];
-
-                $root_failed = isset($bit['error']);
-
-                continue;
-            }
-
-            // There's an error, but the root call hasn't failed
-            if (isset($bit['error']) && !$root_failed)
-            {
-                continue;
-            }
-
-            // Everything has failed, we're not adding any data to save the disk space
-            if ($root_failed)
-            {
-                continue;
-            }
-
-            // Now we have several call types
-            // `call` transfers ethers
-            // `create`/`create2` creates a contract and transfers ethers
-            // `callcode`/`delegatecall`/`staticcall` don't transfer ethers
-            // `selfdestruct` destroys the contract and gets ethers out of it
-
-            if ($bit['type'] === 'create')
-            {
-                // from: action.form, to: result.address, value: action.value
-
-                $events[] = [
-                    'transaction' => $bit['transactionHash'],
-                    'address' => $bit['action']['from'],
-                    'sort_key' => $sort_key++,
-                    'effect' => '-' . to_int256_from_0xhex($bit['action']['value']),
-                    'extra' => EVMSpecialTransactions::ContractCreation->value,
-                ];
-
-                $events[] = [
-                    'transaction' => $bit['transactionHash'],
-                    'address' => $bit['result']['address'],
-                    'sort_key' => $sort_key++,
-                    'effect' => to_int256_from_0xhex($bit['action']['value']),
-                    'extra' => EVMSpecialTransactions::ContractCreation->value,
-                ];
-            }
-            elseif ($bit['type'] === 'suicide')
-            {
-                // from: action.address, to: action.refundAddress, value: action.balance
-
-                $events[] = [
-                    'transaction' => $bit['transactionHash'],
-                    'address' => $bit['action']['address'],
-                    'sort_key' => $sort_key++,
-                    'effect' => '-' . to_int256_from_0xhex($bit['action']['balance']),
-                    'extra' => EVMSpecialTransactions::ContractDestruction->value,
-                ];
-
-                $events[] = [
-                    'transaction' => $bit['transactionHash'],
-                    'address' => $bit['action']['refundAddress'],
-                    'sort_key' => $sort_key++,
-                    'effect' => to_int256_from_0xhex($bit['action']['balance']),
-                    'extra' => EVMSpecialTransactions::ContractDestruction->value,
-                ];
-            }
-            elseif ($bit['action']['callType'] === 'call')
-            {
-                // from: action.from, to: action.to, value: action.value
-
-                if ($bit['action']['value'] === '0x0')
+                // We don't need block reward data as this is already processed by the main module
+                if (!isset($bit['transactionHash']) && ($bit['type'] === 'reward'))
+                {
                     continue;
+                }
 
-                $events[] = [
-                    'transaction' => $bit['transactionHash'],
-                    'address' => $bit['action']['from'],
-                    'sort_key' => $sort_key++,
-                    'effect' => '-' . to_int256_from_0xhex($bit['action']['value']),
-                    'extra' => null,
-                ];
+                // New transaction is being processed
+                if ($bit['transactionHash'] !== $current_transaction)
+                {
+                    // We don't need the root call as it is already processed by the main module
+                    $current_transaction = $bit['transactionHash'];
 
-                $events[] = [
-                    'transaction' => $bit['transactionHash'],
-                    'address' => $bit['action']['to'],
-                    'sort_key' => $sort_key++,
-                    'effect' => to_int256_from_0xhex($bit['action']['value']),
-                    'extra' => null,
-                ];
-            }
-            elseif (in_array($bit['action']['callType'], ['staticcall', 'delegatecall', 'callcode']))
-            {
-                // These types don't transfer ethers
-                continue;
-            }
-            else
-            {
-                throw new ModuleError("Unknown call type for {$bit['transactionHash']}: {$bit['action']['callType']}");
+                    $root_failed = isset($bit['error']);
+
+                    continue;
+                }
+
+                // There's an error, but the root call hasn't failed
+                if (isset($bit['error']) && !$root_failed)
+                {
+                    continue;
+                }
+
+                // Everything has failed, we're not adding any data to save the disk space
+                if ($root_failed)
+                {
+                    continue;
+                }
+
+                // Now we have several call types
+                // `call` transfers ethers
+                // `create`/`create2` creates a contract and transfers ethers
+                // `callcode`/`delegatecall`/`staticcall` don't transfer ethers
+                // `selfdestruct` destroys the contract and gets ethers out of it
+
+                if ($bit['type'] === 'create')
+                {
+                    // from: action.form, to: result.address, value: action.value
+
+                    $events[] = [
+                        'transaction' => $bit['transactionHash'],
+                        'address' => $bit['action']['from'],
+                        'sort_key' => $sort_key++,
+                        'effect' => '-' . to_int256_from_0xhex($bit['action']['value']),
+                        'extra' => EVMSpecialTransactions::ContractCreation->value,
+                    ];
+
+                    $events[] = [
+                        'transaction' => $bit['transactionHash'],
+                        'address' => $bit['result']['address'],
+                        'sort_key' => $sort_key++,
+                        'effect' => to_int256_from_0xhex($bit['action']['value']),
+                        'extra' => EVMSpecialTransactions::ContractCreation->value,
+                    ];
+                }
+                elseif ($bit['type'] === 'suicide')
+                {
+                    // from: action.address, to: action.refundAddress, value: action.balance
+
+                    $events[] = [
+                        'transaction' => $bit['transactionHash'],
+                        'address' => $bit['action']['address'],
+                        'sort_key' => $sort_key++,
+                        'effect' => '-' . to_int256_from_0xhex($bit['action']['balance']),
+                        'extra' => EVMSpecialTransactions::ContractDestruction->value,
+                    ];
+
+                    $events[] = [
+                        'transaction' => $bit['transactionHash'],
+                        'address' => $bit['action']['refundAddress'],
+                        'sort_key' => $sort_key++,
+                        'effect' => to_int256_from_0xhex($bit['action']['balance']),
+                        'extra' => EVMSpecialTransactions::ContractDestruction->value,
+                    ];
+                }
+                elseif ($bit['action']['callType'] === 'call')
+                {
+                    // from: action.from, to: action.to, value: action.value
+
+                    if ($bit['action']['value'] === '0x0')
+                        continue;
+
+                    $events[] = [
+                        'transaction' => $bit['transactionHash'],
+                        'address' => $bit['action']['from'],
+                        'sort_key' => $sort_key++,
+                        'effect' => '-' . to_int256_from_0xhex($bit['action']['value']),
+                        'extra' => null,
+                    ];
+
+                    $events[] = [
+                        'transaction' => $bit['transactionHash'],
+                        'address' => $bit['action']['to'],
+                        'sort_key' => $sort_key++,
+                        'effect' => to_int256_from_0xhex($bit['action']['value']),
+                        'extra' => null,
+                    ];
+                }
+                elseif (in_array($bit['action']['callType'], ['staticcall', 'delegatecall', 'callcode']))
+                {
+                    // These types don't transfer ethers
+                    continue;
+                }
+                else
+                {
+                    throw new ModuleError("Unknown call type for {$bit['transactionHash']}: {$bit['action']['callType']}");
+                }
             }
         }
 

--- a/Modules/Common/EVMTraits.php
+++ b/Modules/Common/EVMTraits.php
@@ -27,6 +27,7 @@ enum EVMSpecialFeatures
 {
     case HasOrHadUncles;
     case BorValidator;
+    case AllowEmptyRecipient;
 }
 
 trait EVMTraits


### PR DESCRIPTION
This PR proposes adding full Arbitrum support (main, trace, ERC-20, ERC-721, ERC-1155 modules). For traces, it adds an ability to trace blocks using geth instead of Erigon.