### PR TITLE
Add withdrawal processing to Ethereum

### DIFF
--- a/Modules/Common/EVMTraits.php
+++ b/Modules/Common/EVMTraits.php
@@ -21,6 +21,7 @@ enum EVMSpecialTransactions: string
     case UncleReward = 'u';
     case ContractCreation = 'c';
     case ContractDestruction = 'd';
+    case Withdrawal = 'w';
 }
 
 enum EVMSpecialFeatures
@@ -28,6 +29,7 @@ enum EVMSpecialFeatures
     case HasOrHadUncles;
     case BorValidator;
     case AllowEmptyRecipient;
+    case PoSWithdrawals;
 }
 
 trait EVMTraits

--- a/Modules/EthereumMainModule.php
+++ b/Modules/EthereumMainModule.php
@@ -20,7 +20,8 @@ final class EthereumMainModule extends EVMMainModule implements Module
 
         // EVMMainModule
         $this->evm_implementation = EVMImplementation::Erigon; // Change to geth if you're running geth, but this would be slower
-        $this->extra_features = [EVMSpecialFeatures::HasOrHadUncles];
+        $this->extra_features = [EVMSpecialFeatures::HasOrHadUncles, EVMSpecialFeatures::PoSWithdrawals];
+        $this->staking_contract = '0x00000000219ab540356cbb839cbe05303d7705fa';
         $this->reward_function = function($block_id)
         {
             if ($block_id >= 0 && $block_id <= 4_369_999)


### PR DESCRIPTION
This PR proposes adding withdrawals. Withdrawals are processed after all transactions and rewards. The sender is always the staking contract address.