### PR TITLE
Split Beacon Chain into 4 modules

### DIFF
--- a/Modules/BeaconChainAttestationsModule.php
+++ b/Modules/BeaconChainAttestationsModule.php
@@ -4,26 +4,26 @@
  *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
  *  Distributed under the MIT software license, see LICENSE.md  */
 
-/*  This is the Deposits & Withdrawals (main) module for Beacon Chain. It requires a Prysm or a Lighthouse node to run.  */
+/*  This is the Attestations module for Beacon Chain. It requires a Prysm or a Lighthouse node to run.  */
 
-final class BeaconChainMainModule extends BeaconChainLikeMainModule implements Module
+final class BeaconChainAttestationsModule extends BeaconChainLikeAttestationsModule implements Module
 {
     function initialize()
     {
         // CoreModule
         $this->blockchain = 'beacon-chain';
-        $this->module = 'beacon-chain-main';
-        $this->is_main = true;
+        $this->module = 'beacon-chain-attestations';
+        $this->complements = 'beacon-chain-main';
+        $this->is_main = false;
         $this->first_block_date = '2020-12-01';
         $this->first_block_id = 0;
-        $this->currency = 'beacon-ethereum'; // We can't use `ethereum` here as this one has a different number of decimals
-        $this->currency_details = ['name' => 'Ethereum', 'symbol' => 'ETH', 'decimals' => 9, 'description' => null];
 
         // BeaconChainLikeModule
         $this->chain_config = [
+            'ALTAIR_FORK_EPOCH' => 74240,
             'BELLATRIX_FORK_EPOCH' => 144896,
             'SLOT_PER_EPOCH' => 32,
             'DELAY' => 2,
-        ];
+            ];
     }
 }

--- a/Modules/BeaconChainMainModule.php
+++ b/Modules/BeaconChainMainModule.php
@@ -24,6 +24,7 @@ final class BeaconChainMainModule extends BeaconChainLikeMainModule implements M
             'BELLATRIX_FORK_EPOCH' => 144896,
             'SLOT_PER_EPOCH' => 32,
             'DELAY' => 2,
+            'CAPELLA_FORK_EPOCH' => 194048,
         ];
     }
 }

--- a/Modules/BeaconChainPenaltiesModule.php
+++ b/Modules/BeaconChainPenaltiesModule.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+/*  Idea (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
+ *  Distributed under the MIT software license, see LICENSE.md  */
+
+/*  This is the Penalties module for Beacon Chain. It requires a Prysm or a Lighthouse node to run.  */
+
+final class BeaconChainPenaltiesModule extends BeaconChainLikePenaltiesModule implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'beacon-chain';
+        $this->module = 'beacon-chain-penalties';
+        $this->complements = 'beacon-chain-main';
+        $this->is_main = false;
+        $this->first_block_date = '2020-12-01';
+        $this->first_block_id = 0;
+
+        // BeaconChainLikeModule
+        $this->chain_config = [
+            'PHASE0_FORK_EPOCH' => 0,
+            'ALTAIR_FORK_EPOCH' => 74240,
+            'BELLATRIX_FORK_EPOCH' => 144896,
+            'MIN_SLASHING_PENALTY_QUOTIENT' => 128,
+            'MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR' => 64,
+            'MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX' => 32,
+            'WHISTLEBLOWER_REWARD_QUOTIENT' => 512,
+            'SLOT_PER_EPOCH' => 32,
+            'DELAY' => 2,
+            ];
+    }
+}

--- a/Modules/BeaconChainProposalsModule.php
+++ b/Modules/BeaconChainProposalsModule.php
@@ -4,20 +4,19 @@
  *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
  *  Distributed under the MIT software license, see LICENSE.md  */
 
-/*  This is the Deposits & Withdrawals (main) module for Beacon Chain. It requires a Prysm or a Lighthouse node to run.  */
+/*  This is the Proposals module for Beacon Chain. It requires a Prysm or a Lighthouse node to run.  */
 
-final class BeaconChainMainModule extends BeaconChainLikeMainModule implements Module
+final class BeaconChainProposalsModule extends BeaconChainLikeProposalsModule implements Module
 {
     function initialize()
     {
         // CoreModule
         $this->blockchain = 'beacon-chain';
-        $this->module = 'beacon-chain-main';
-        $this->is_main = true;
+        $this->module = 'beacon-chain-proposals';
+        $this->complements = 'beacon-chain-main';
+        $this->is_main = false;
         $this->first_block_date = '2020-12-01';
         $this->first_block_id = 0;
-        $this->currency = 'beacon-ethereum'; // We can't use `ethereum` here as this one has a different number of decimals
-        $this->currency_details = ['name' => 'Ethereum', 'symbol' => 'ETH', 'decimals' => 9, 'description' => null];
 
         // BeaconChainLikeModule
         $this->chain_config = [

--- a/Modules/Common/BeaconChainLikeAttestationsModule.php
+++ b/Modules/Common/BeaconChainLikeAttestationsModule.php
@@ -234,29 +234,13 @@ abstract class BeaconChainLikeAttestationsModule extends CoreModule
 
         foreach ($rewards as $validator => $reward)
         {
-            $this_void = bcmul($reward, '-1');
-            $this_void = ($this_void === '0') ? '-0' : $this_void;
-
-            if (str_contains($this_void, '-'))
-            {
-                $events[] = [
-                    'block' => $block,
-                    'sort_key' => $key_tes++,
-                    'time' => $this->block_time,
-                    'address' => (string)$validator,
-                    'effect' => $reward,
-                ];
-            }
-            else
-            {
-                $events[] = [
-                    'block' => $block,
-                    'sort_key' => $key_tes++,
-                    'time' => $this->block_time,
-                    'address' => (string)$validator,
-                    'effect' => $reward,
-                ];
-            }
+            $events[] = [
+                'block' => $block,
+                'sort_key' => $key_tes++,
+                'time' => $this->block_time,
+                'address' => (string)$validator,
+                'effect' => $reward,
+            ];
         }
 
         $this->set_return_events($events);

--- a/Modules/Common/BeaconChainLikeAttestationsModule.php
+++ b/Modules/Common/BeaconChainLikeAttestationsModule.php
@@ -13,8 +13,8 @@ abstract class BeaconChainLikeAttestationsModule extends CoreModule
 
     public ?BlockHashFormat $block_hash_format = BlockHashFormat::HexWithout0x;
     public ?AddressFormat $address_format = AddressFormat::AlphaNumeric;
-    public ?TransactionHashFormat $transaction_hash_format = TransactionHashFormat::AlphaNumeric;
-    public ?TransactionRenderModel $transaction_render_model = TransactionRenderModel::Mixed;
+    public ?TransactionHashFormat $transaction_hash_format = TransactionHashFormat::None;
+    public ?TransactionRenderModel $transaction_render_model = TransactionRenderModel::None;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
     public ?bool $hidden_values_only = false;
 

--- a/Modules/Common/BeaconChainLikeMainModule.php
+++ b/Modules/Common/BeaconChainLikeMainModule.php
@@ -58,6 +58,7 @@ abstract class BeaconChainLikeMainModule extends CoreModule
     final public function post_post_initialize()
     {
         if (!isset($this->chain_config['BELLATRIX_FORK_EPOCH'])) throw new DeveloperError("`BELLATRIX_FORK_EPOCH` is not set");
+        if (!isset($this->chain_config['CAPELLA_FORK_EPOCH'])) throw new DeveloperError("`CAPELLA_FORK_EPOCH` is not set");
         if (!isset($this->chain_config['SLOT_PER_EPOCH'])) throw new DeveloperError("`SLOT_PER_EPOCH` is not set");
         if (!isset($this->chain_config['DELAY'])) throw new DeveloperError("`DELAY` is not set");
     }
@@ -93,6 +94,7 @@ abstract class BeaconChainLikeMainModule extends CoreModule
 
         foreach ($slot_data as $slot_info)
         {
+            $withdrawal = [];
             if (isset($slot_info['code']) && $slot_info['code'] === '404')
                 continue;
             elseif (isset($slot_info['code']))
@@ -103,7 +105,10 @@ abstract class BeaconChainLikeMainModule extends CoreModule
             if (isset($slot_info['data']['message']['body']['execution_payload']))
             {
                 $timestamp = (int)$slot_info['data']['message']['body']['execution_payload']['timestamp'];
-                $withdrawal = $slot_info['data']['message']['body']['execution_payload']['withdrawals'];
+                if ($block >= $this->chain_config['CAPELLA_FORK_EPOCH'])
+                {
+                    $withdrawal = $slot_info['data']['message']['body']['execution_payload']['withdrawals'];
+                }
             }
             else
             {

--- a/Modules/Common/BeaconChainLikePenaltiesModule.php
+++ b/Modules/Common/BeaconChainLikePenaltiesModule.php
@@ -284,15 +284,15 @@ abstract class BeaconChainLikePenaltiesModule extends CoreModule
                 $attestors_slashing[$proposer_index][2] = $rq['data']['attester_slashings'];
             }
 
-            if (isset($proposer_slashings[$proposer_index]))
+            if (isset($proposers_slashing[$proposer_index]))
             {
-                $proposer_slashings[$proposer_index][2] = $rq['data']['proposer_slashings'];
+                $proposers_slashing[$proposer_index][2] = $rq['data']['proposer_slashings'];
             }
         }
 
         $key_tes = 0;
 
-        foreach ($proposer_slashings as $index => [$slashed, $slot, $reward])
+        foreach ($proposers_slashing as $index => [$slashed, $slot, $reward])
         {
             foreach ($slashed as $validator_index => [$reward_for_slashing, $penalty])
             {

--- a/Modules/Common/BeaconChainLikePenaltiesModule.php
+++ b/Modules/Common/BeaconChainLikePenaltiesModule.php
@@ -1,0 +1,418 @@
+<?php declare(strict_types = 1);
+
+/*  Idea (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
+ *  Distributed under the MIT software license, see LICENSE.md  */
+
+/*  This module processes various penalties happening on the Beacon Chain.
+ *  It requires a Prysm-like node to run.  */
+
+abstract class BeaconChainLikePenaltiesModule extends CoreModule
+{
+    use BeaconChainLikeTraits;
+
+    public ?BlockHashFormat $block_hash_format = BlockHashFormat::HexWithout0x;
+    public ?AddressFormat $address_format = AddressFormat::AlphaNumeric;
+    public ?TransactionHashFormat $transaction_hash_format = TransactionHashFormat::AlphaNumeric;
+    public ?TransactionRenderModel $transaction_render_model = TransactionRenderModel::Mixed;
+    public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
+    public ?bool $hidden_values_only = false;
+
+    public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect', 'extra', 'extra_indexed'];
+    public ?array $events_table_nullable_fields = ['extra_indexed'];
+
+    public ?bool $should_return_events = true;
+    public ?bool $should_return_currencies = false;
+    public ?bool $allow_empty_return_events = true;
+
+    public ?bool $mempool_implemented = false;
+    public ?bool $forking_implemented = false;
+
+    public ?ExtraDataModel $extra_data_model = ExtraDataModel::Type;
+    public ?array $extra_data_details = [
+        'sa' => 'Reward for slashing attestor',
+        'sp' => 'Reward for slashing proposer',
+        'ap' => 'Attestor penalty',
+        'pp' => 'Proposer penalty',
+    ];
+
+    public ?bool $ignore_sum_of_all_effects = true; // Essentially, all events here always come in pair with `the-void`, but we don't
+    // put that into the database to save space.
+
+    public string $block_entity_name = 'epoch';
+    public string $transaction_entity_name = 'slot';
+    public string $address_entity_name = 'validator';
+
+    //
+
+    public array $chain_config = [];
+
+    //
+
+    final public function pre_initialize()
+    {
+        $this->version = 1;
+    }
+
+    final public function post_post_initialize()
+    {
+        if (!isset($this->chain_config['PHASE0_FORK_EPOCH'])) throw new DeveloperError("`PHASE0_FORK_EPOCH` is not set");
+        if (!isset($this->chain_config['ALTAIR_FORK_EPOCH'])) throw new DeveloperError("`ALTAIR_FORK_EPOCH` is not set");
+        if (!isset($this->chain_config['BELLATRIX_FORK_EPOCH'])) throw new DeveloperError("`BELLATRIX_FORK_EPOCH` is not set");
+        if (!isset($this->chain_config['MIN_SLASHING_PENALTY_QUOTIENT'])) throw new DeveloperError("`MIN_SLASHING_PENALTY_QUOTIENT` is not set");
+        if (!isset($this->chain_config['MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR'])) throw new DeveloperError("`MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR` is not set");
+        if (!isset($this->chain_config['MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX'])) throw new DeveloperError("`MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX` is not set");
+        if (!isset($this->chain_config['WHISTLEBLOWER_REWARD_QUOTIENT'])) throw new DeveloperError("`WHISTLEBLOWER_REWARD_QUOTIENT` is not set");
+        if (!isset($this->chain_config['SLOT_PER_EPOCH'])) throw new DeveloperError("`SLOT_PER_EPOCH` is not set");
+        if (!isset($this->chain_config['DELAY'])) throw new DeveloperError("`DELAY` is not set");
+    }
+
+    final public function pre_process_block($block) // $block here is an epoch number
+    {
+        $events = [];
+        $rewards = [];
+        $rq_blocks = [];
+        $rq_committees = [];
+        $rq_blocks_data = [];
+        $rq_committees_data = [];
+        $rq_slot_time = [];
+        $attestors_slashing = [];   // [validator] -> [[validator_index => penalty], slot, amount]
+        $proposers_slashing = [];   // [validator] -> [[validator_index => penalty], slot, amount]
+        $slot_data = [];
+
+        $proposers = requester_single($this->select_node(),
+            endpoint: "eth/v1/validator/duties/proposer/{$block}",
+            timeout: $this->timeout,
+            result_in: 'data',
+        );
+
+        foreach ($proposers as $proposer)
+            $slots[$proposer['slot']] = null;
+
+        foreach ($slots as $slot => $tm)
+            $rq_slot_time[] = requester_multi_prepare($this->select_node(), endpoint: "eth/v1/beacon/blocks/{$slot}");
+
+        $rq_slot_time_multi = requester_multi($rq_slot_time,
+            limit: envm($this->module, 'REQUESTER_THREADS'),
+            timeout: $this->timeout,
+            valid_codes: [200, 404],
+        );
+
+        foreach ($rq_slot_time_multi as $slot)
+            $slot_data[] = requester_multi_process($slot);
+
+        foreach ($slot_data as $slot_info)
+        {
+            if (isset($slot_info['code']) && $slot_info['code'] === '404')
+                continue;
+            elseif (isset($slot_info['code']))
+                throw new ModuleError('Unexpected response code');
+
+            $proposer = $slot_info['data']['message']['proposer_index'];
+            $slot_id = (string)$slot_info['data']['message']['slot'];
+
+            if (isset($slot_info['data']['message']['body']['execution_payload']))
+            {
+                $timestamp = (int)$slot_info['data']['message']['body']['execution_payload']['timestamp'];
+            }
+            else
+            {
+                $timestamp = 0;
+            }
+
+            $slots[$slot_id] = $timestamp;
+
+            $attester_slashings = $slot_info['data']['message']['body']['attester_slashings'];
+
+            foreach ($attester_slashings as $as)
+            {
+                $attestation_1 = $as['attestation_1']['attesting_indices'];
+                $attestation_2 = $as['attestation_2']['attesting_indices'];
+
+                $slashed_1 = $this->ask_slashed_validators(attestationGroup: $attestation_1, slot: $slot_id);
+                $slashed_2 = $this->ask_slashed_validators(attestationGroup: $attestation_2, slot: $slot_id);
+
+                $slashed = $slashed_1 + $slashed_2;
+
+                if (count($slashed) > 0)
+                {
+                    if (isset($attestors_slashing[$proposer]))
+                    {
+                        $attestors_slashing[$proposer][0] = $attestors_slashing[$proposer][0] + $slashed;
+                    }
+                    else
+                    {
+                        $attestors_slashing[$proposer][0] = $slashed;
+                        $attestors_slashing[$proposer][1] = $slot_id;
+                    }
+                }
+            }
+
+            $proposer_slashings = $slot_info['data']['message']['body']['proposer_slashings'];
+
+            foreach($proposer_slashings as $as)
+            {
+                $attestation_1 = $as['signed_header_1']['message']['proposer_index'];
+                $attestation_2 = $as['signed_header_2']['message']['proposer_index'];
+
+                $slashed_1 = $this->ask_slashed_validators(attestationGroup: [$attestation_1], slot: $slot_id);
+                $slashed_2 = $this->ask_slashed_validators(attestationGroup: [$attestation_2], slot: $slot_id);
+
+                $slashed = $slashed_1 + $slashed_2;
+
+                if (count($slashed) > 0)
+                {
+                    if (isset($proposers_slashing[$proposer]))
+                    {
+                        $proposers_slashing[$proposer][0] = $proposers_slashing[$proposer][0] + $slashed;
+                    }
+                    else
+                    {
+                        $proposers_slashing[$proposer][0] = $slashed;
+                        $proposers_slashing[$proposer][1] = $slot_id;
+                    }
+                }
+            }
+        }
+
+        if ($block < $this->chain_config['BELLATRIX_FORK_EPOCH'])
+        {
+            $last_slot = max(array_keys($slots));
+
+            $last_slot = requester_single(
+                $this->select_node(),
+                endpoint: "eth/v1/beacon/blocks/{$last_slot}",
+                timeout: $this->timeout,
+                result_in: 'data',
+            );
+
+            $block_hash = $last_slot['message']['body']['eth1_data']['block_hash'];
+            $execution_layers = envm($this->module, 'EXECUTION_LAYER_NODES');
+            $execution_layer = $execution_layers[array_rand($execution_layers)];
+
+            $last_block_time = requester_single(
+                $execution_layer,
+                params: ['jsonrpc' => '2.0', 'method' => 'eth_getBlockByHash', 'params' => [$block_hash, false], 'id' => 0],
+                timeout: $this->timeout,
+                result_in: 'result'
+            );
+
+            $block_time = hexdec($last_block_time['timestamp']);
+            $slot_keys = array_keys($slots);
+
+            foreach($slot_keys as $slot)
+                if ($slots[$slot] !== null)
+                    $slots[$slot] = $block_time;
+
+            $this->block_time = date('Y-m-d H:i:s', hexdec($last_block_time['timestamp']));
+        }
+        else
+        {
+            $this_slot_times = array_reverse($slots);
+
+            foreach ($this_slot_times as $time)
+            {
+                if (!is_null($time))
+                {
+                    $this->block_time = date('Y-m-d H:i:s', $time);
+                    break;
+                }
+            }
+        }
+
+        foreach ($slots as $slot => $tm)
+            $rq_blocks[] = requester_multi_prepare($this->select_node(), endpoint: "eth/v1/beacon/rewards/blocks/{$slot}");
+
+        $rq_blocks_multi = requester_multi($rq_blocks,
+            limit: envm($this->module, 'REQUESTER_THREADS'),
+            timeout: $this->timeout,
+            valid_codes: [200, 404]
+        );
+
+        foreach ($rq_blocks_multi as $v)
+            $rq_blocks_data[] = requester_multi_process($v);
+
+        if ($block >= $this->chain_config['ALTAIR_FORK_EPOCH'])
+        {
+            foreach ($slots as $slot => $tm)
+                $rq_committees[] = requester_multi_prepare(
+                    $this->select_node(),
+                    endpoint: "eth/v1/beacon/rewards/sync_committee/{$slot}",
+                    params: '[]',
+                    no_json_encode: true
+                );
+
+            $rq_committees_multi = requester_multi(
+                $rq_committees,
+                limit: envm($this->module, 'REQUESTER_THREADS'),
+                timeout: $this->timeout,
+                valid_codes: [200, 404]
+            );
+            foreach ($rq_committees_multi as $v)
+                $rq_committees_data[] = requester_multi_process($v);
+
+            foreach ($rq_committees_data as $slot_rewards) 
+            {
+                if (isset($slot_rewards['code']) && $slot_rewards['code'] === '404')
+                    continue;
+                elseif (isset($slot_rewards['code']))
+                    throw new ModuleError('Unexpected response code');
+
+                $slot_rewards = $slot_rewards['data'];
+
+                foreach ($slot_rewards as $rw) 
+                {
+                    if (isset($rewards[$rw['validator_index']]))
+                        $rewards[$rw['validator_index']] = bcadd($rw['reward'], $rewards[$rw['validator_index']]);
+                    else
+                        $rewards[$rw['validator_index']] = $rw['reward'];
+                }
+            }
+        }
+
+        foreach ($rq_blocks_data as $rq)
+        {
+            if (isset($rq['code']) && $rq['code'] === '404')
+                continue;
+            elseif (isset($rq['code']))
+                throw new ModuleError('Unexpected response code');
+
+            $proposer_index = $rq['data']['proposer_index'];
+
+            if (isset($attestors_slashing[$proposer_index]))
+            {
+                $attestors_slashing[$proposer_index][2] = $rq['data']['attester_slashings'];
+            }
+
+            if (isset($proposer_slashings[$proposer_index]))
+            {
+                $proposer_slashings[$proposer_index][2] = $rq['data']['proposer_slashings'];
+            }
+        }
+
+        $key_tes = 0;
+
+        foreach ($proposer_slashings as $index => [$slashed, $slot, $reward])
+        {
+            foreach ($slashed as $validator_index => [$reward_for_slashing, $penalty])
+            {
+                $events[] = [
+                    'block' => $block,
+                    'transaction' => $slot,
+                    'sort_key' => $key_tes++,
+                    'time' => $this->block_time,
+                    'address' => (string)$index,
+                    'effect' => $reward_for_slashing,
+                    'extra' => 'sp',
+                    'extra_indexed' => (string)$validator_index
+                ];
+
+                $events[] = [
+                    'block' => $block,
+                    'transaction' => $slot,
+                    'sort_key' => $key_tes++,
+                    'time' => $this->block_time,
+                    'address' => (string)$validator_index,
+                    'effect' => '-' . $penalty,
+                    'extra' => 'pp',
+                    'extra_indexed' => null
+                ];
+            }
+        }
+
+        foreach ($attestors_slashing as $index => [$slashed, $slot, $reward])
+        {
+            foreach ($slashed as $validator_index => [$reward_for_slashing, $penalty])
+            {
+                // As *all* events come in pairs with `the-void` and validators don't interact with each other, we
+                // technically don't need transfers to or from `the-void`. At the current rate, this saves more than
+                // 1.500 events per second!
+    
+                $events[] = [
+                    'block' => $block,
+                    'transaction' => $slot,
+                    'sort_key' => $key_tes++,
+                    'time' => $this->block_time,
+                    'address' => (string)$index,
+                    'effect' => $reward_for_slashing,
+                    'extra' => 'sa',
+                    'extra_indexed' => (string)$validator_index
+                ];
+
+                $events[] = [
+                    'block' => $block,
+                    'transaction' => $slot,
+                    'sort_key' => $key_tes++,
+                    'time' => $this->block_time,
+                    'address' => (string)$validator_index,
+                    'effect' => '-' . $penalty,
+                    'extra' => 'ap',
+                    'extra_indexed' => null
+                ];
+            }
+        }
+
+        $this->set_return_events($events);
+    }
+
+    // Private module functions
+
+    private function ask_slashed_validators($attestationGroup = [], $slot = 'head')
+    {
+        $slashed_validators = [];
+
+        foreach ($attestationGroup as $at)
+            $rq_validator_info[] = requester_multi_prepare($this->select_node(), endpoint: "/eth/v1/beacon/states/{$slot}/validators/{$at}");
+
+        $rq_validator_info_multi = requester_multi(
+            $rq_validator_info,
+            limit: envm($this->module, 'REQUESTER_THREADS'),
+            timeout: $this->timeout
+        );
+
+        foreach ($rq_validator_info_multi as $v)
+        {
+            $validator_info = requester_multi_process($v, result_in: 'data');
+
+            if ($validator_info['validator']['slashed'] === true && !$this->check_validator_slashed($validator_info['index'], $slot))
+            {
+                if ((int)($slot / $this->chain_config['SLOT_PER_EPOCH']) >= $this->chain_config['PHASE0_FORK_EPOCH'] && (int)($slot / $this->chain_config['SLOT_PER_EPOCH']) < $this->chain_config['ALTAIR_FORK_EPOCH']) // Phase0
+                {
+                    $reward = (int)($validator_info['validator']['effective_balance'] / $this->chain_config['WHISTLEBLOWER_REWARD_QUOTIENT']);
+                    $slash_penalty = (int)($validator_info['validator']['effective_balance'] / $this->chain_config['MIN_SLASHING_PENALTY_QUOTIENT']);
+                }
+                elseif ((int)($slot / $this->chain_config['SLOT_PER_EPOCH']) >= $this->chain_config['ALTAIR_FORK_EPOCH'] && (int)($slot / $this->chain_config['SLOT_PER_EPOCH']) < $this->chain_config['BELLATRIX_FORK_EPOCH']) // Altair
+                { 
+                    $reward = (int)(($validator_info['validator']['effective_balance'] / $this->chain_config['WHISTLEBLOWER_REWARD_QUOTIENT']));
+                    $slash_penalty = (int)($validator_info['validator']['effective_balance'] / $this->chain_config['MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR']);
+                }
+                else//if ((int)($slot / $this->chain_config['SLOT_PER_EPOCH']) >= $this->chain_config['BELLATRIX_FORK_EPOCH']) // Bellatrix+
+                {
+                    $reward = (int)(($validator_info['validator']['effective_balance'] / $this->chain_config['WHISTLEBLOWER_REWARD_QUOTIENT']));
+                    $slash_penalty = (int)($validator_info['validator']['effective_balance'] / $this->chain_config['MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX']);
+                }
+
+                $slashed_validators[$validator_info['index']] = [strval($reward), strval($slash_penalty)];
+            }
+        }
+
+        return $slashed_validators;
+    }
+
+    private function check_validator_slashed($validator_index, $slot_id)
+    {
+        $slot_id -= 1;
+
+        $state = requester_single(
+            $this->select_node(),
+            endpoint: "/eth/v1/beacon/states/{$slot_id}/validators/{$validator_index}",
+            timeout: $this->timeout,
+            result_in: 'data',
+        );
+
+        if ($state['validator']['slashed'] === true)
+            return true;
+
+        return false;
+    }
+}

--- a/Modules/Common/BeaconChainLikeTraits.php
+++ b/Modules/Common/BeaconChainLikeTraits.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+/*  Idea (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
+ *  Distributed under the MIT software license, see LICENSE.md  */
+
+/*  Common functions for Beacon Chain modules  */
+
+trait BeaconChainLikeTraits
+{
+    public function inquire_latest_block()
+    {
+        $result = requester_single($this->select_node(),
+            endpoint: 'eth/v1/beacon/headers',
+            timeout: $this->timeout,
+            result_in: 'data');
+
+        return intdiv((int)$result[0]['header']['message']['slot'], $this->chain_config['SLOT_PER_EPOCH']) - $this->chain_config['DELAY'];
+    }
+
+    public function ensure_block($block, $break_on_first = false)
+    {
+        $hashes = [];
+
+        $block_start = $block * $this->chain_config['SLOT_PER_EPOCH'];
+        $block_end = $block_start + ($this->chain_config['SLOT_PER_EPOCH'] - 1);
+
+        foreach ($this->nodes as $node)
+        {
+            $multi_curl = [];
+
+            for ($i = $block_start; $i <= $block_end; $i++)
+            {
+                $multi_curl[] = requester_multi_prepare($node,
+                    endpoint: "eth/v1/beacon/headers/{$i}",
+                    timeout: $this->timeout,
+                );
+            }
+
+            $curl_results = requester_multi(
+                $multi_curl,
+                limit: envm($this->module, 'REQUESTER_THREADS'),
+                timeout: $this->timeout,
+                valid_codes: [200, 404],
+            );
+
+            foreach ($curl_results as $result)
+            {
+                $hash_result = requester_multi_process($result);
+
+                if (isset($hash_result['code']) && $hash_result['code'] === '404')
+                    continue;
+                elseif (isset($hash_result['code']))
+                    throw new ModuleError('Unexpected response code');
+
+                $root = $hash_result['data']['root'];
+                $slot = $hash_result['data']['header']['message']['slot'];
+
+                $hashes_res[$slot] = $root;
+            }
+
+            ksort($hashes_res);
+            $hash = join($hashes_res);
+            $hashes[] = $hash;
+
+            if ($break_on_first)
+                break;
+        }
+
+        if (isset($hashes[1]))
+            for ($i = 1; $i < count($hashes); $i++)
+                if ($hashes[0] !== $hashes[$i])
+                    throw new ConsensusException("ensure_block(block_id: {$block}): no consensus");
+
+        $hashes[0] = str_replace('0x', '', $hashes[0]);
+
+        $this->block_hash = $hashes[0];
+        $this->block_id = $block;
+    }
+}

--- a/Modules/Common/CoreModule.php
+++ b/Modules/Common/CoreModule.php
@@ -210,7 +210,7 @@ abstract class CoreModule
             if ($this->transaction_hash_format !== TransactionHashFormat::None && $this->transaction_hash_format !== $complemented->transaction_hash_format)
                 throw new DeveloperError("`transaction_hash_format` mismatch for complemented module `{$this->complements}`");
 
-            if ($this->transaction_hash_format !== TransactionHashFormat::None && $this->transaction_render_model !== $complemented->transaction_render_model)
+            if ($this->transaction_render_model !== TransactionRenderModel::None && $this->transaction_render_model !== $complemented->transaction_render_model)
                 throw new DeveloperError("`transaction_render_model` mismatch for complemented module `{$this->complements}`");
 
             if ($this->should_return_currencies || $complemented->should_return_currencies)

--- a/Modules/Common/CoreModule.php
+++ b/Modules/Common/CoreModule.php
@@ -207,10 +207,10 @@ abstract class CoreModule
             if ($this->address_format !== $complemented->address_format)
                 throw new DeveloperError("`address_format` mismatch for complemented module `{$this->complements}`");
 
-            if ($this->transaction_hash_format !== $complemented->transaction_hash_format)
+            if ($this->transaction_hash_format !== TransactionHashFormat::None && $this->transaction_hash_format !== $complemented->transaction_hash_format)
                 throw new DeveloperError("`transaction_hash_format` mismatch for complemented module `{$this->complements}`");
 
-            if ($this->transaction_render_model !== $complemented->transaction_render_model)
+            if ($this->transaction_hash_format !== TransactionHashFormat::None && $this->transaction_render_model !== $complemented->transaction_render_model)
                 throw new DeveloperError("`transaction_render_model` mismatch for complemented module `{$this->complements}`");
 
             if ($this->should_return_currencies || $complemented->should_return_currencies)


### PR DESCRIPTION
Currently, Beacon Chain is processed by a single module. The main issue is that there are lots (~1M) attestation per epoch.

1. If we want to prune old epochs, it also prunes deposit data, etc.
2. As 3xpl API doesn't provide a way to filter by `extra` it's not trivial to find e.g. validator withdrawals as they're mixed with attestations

This PR proposes splitting Beacon into 4 modules.