### PR TITLE
Extend the core with privacy models + Add Monero support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -870,3 +870,21 @@ MODULE_peercoin-main_NODES[]=http://login:password@127.0.0.1:1234/
 MODULE_peercoin-main_NODES[]=http://login:password@127.0.0.2:1234/
 MODULE_peercoin-main_REQUESTER_TIMEOUT=60
 MODULE_peercoin-main_REQUESTER_THREADS=12
+
+##########
+# Monero #
+##########
+
+FRONT_monero_ECOSYSTEM_TITLE=Monero Ecosystem
+FRONT_monero_ECOSYSTEM_DESCRIPTION=Includes Monero only
+FRONT_monero_BLOCKCHAIN_TITLE=Monero
+FRONT_monero_BLOCKCHAIN_DESCRIPTION=Transact privately and with anonymity
+FRONT_monero-main_MODULE_TITLE=Main
+FRONT_monero-main_MODULE_DESCRIPTION=Main Monero transfers
+
+MODULES[]=monero-main
+MODULE_monero-main_CLASS=MoneroMainModule
+MODULE_monero-main_NODES[]=http://login:password@127.0.0.1:1234/
+MODULE_monero-main_NODES[]=http://login:password@127.0.0.2:1234/
+MODULE_monero-main_REQUESTER_TIMEOUT=60
+MODULE_monero-main_REQUESTER_THREADS=12

--- a/3xpl.php
+++ b/3xpl.php
@@ -240,10 +240,21 @@ elseif ($chosen_option === 'B')
 
             $event['sign'] = (str_contains($event['effect'], '-')) ? '-1' : '1';
 
-            if ($module->hidden_values_only)
-                $event['effect'] = null;
-            else
+            if ($module->privacy_model === PrivacyModel::Transparent)
+            {
                 $event['effect'] = str_replace('-', '', $event['effect']);
+            }
+            elseif ($module->privacy_model === PrivacyModel::Mixed)
+            {
+                if (in_array($event['effect'], ['-?', '+?']))
+                    $event['effect'] = null;
+                else
+                    $event['effect'] = str_replace('-', '', $event['effect']);
+            }
+            else // Shielded
+            {
+                $event['effect'] = null;
+            }
 
             if (isset($event['failed']))
                 $event['valid'] = ($event['failed'] === true || $event['failed'] === 't') ? '-1' : '1';

--- a/Engine/Enums.php
+++ b/Engine/Enums.php
@@ -104,3 +104,10 @@ enum ExtraDataModel: string
     case Identifier = 'Identifier'; // This is reserved for NFT transfers: the NFT id is stored here
     case None = 'Zilch'; // There's no extra data for the module
 }
+
+enum PrivacyModel
+{
+    case Transparent; // Every event has a known value
+    case Mixed; // Any value is acceptable, including `-?` and `+?`
+    case Shielded; // The only allowed values are `-?` and `+?`
+}

--- a/Modules/Common/BeaconChainLikeMainModule.php
+++ b/Modules/Common/BeaconChainLikeMainModule.php
@@ -17,7 +17,7 @@ abstract class BeaconChainLikeMainModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
 //    public ?array $special_addresses = ['the-void'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect', 'extra', 'extra_indexed'];
     public ?array $events_table_nullable_fields = ['transaction', 'extra_indexed'];

--- a/Modules/Common/CardanoLikeMainModule.php
+++ b/Modules/Common/CardanoLikeMainModule.php
@@ -19,7 +19,7 @@ abstract class CardanoLikeMainModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::LastEventToTheVoid;
     public ?array $special_addresses = ['the-void', 'staking-pool'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect'];
     public ?array $events_table_nullable_fields = [];

--- a/Modules/Common/CoreModule.php
+++ b/Modules/Common/CoreModule.php
@@ -34,8 +34,7 @@ abstract class CoreModule
 
     public ?bool $mempool_implemented = null; // Will this module process mempool transactions?
     public ?bool $forking_implemented = null; // Can blocks be orphaned on this blockchain?
-    public ?bool $hidden_values_only = null; // Set to true if it's not to possible to know transferred values (this is true
-    // for example for MWEB in Litecoin or for Monero)
+    public ?PrivacyModel $privacy_model = null; // Sets whether there can be unknown values (`-?` and `+?`)
 
     // Entity formats
 
@@ -291,8 +290,8 @@ abstract class CoreModule
         if ($this->extra_data_model === ExtraDataModel::Identifier && !is_null($this->extra_data_details))
             throw new DeveloperError("`extra_data_model` is `Identifier` and `extra_data_details` is not null");
 
-        if (is_null($this->hidden_values_only))
-            throw new DeveloperError("`hidden_values_only` is not set");
+        if (is_null($this->privacy_model))
+            throw new DeveloperError("`privacy_model` is not set");
 
         if ($this->currency_format === CurrencyFormat::Static && in_array('currency', $this->events_table_fields))
             throw new DeveloperError("`currency_format` is `Static`, but `currency` is listed among `events_table_fields`");
@@ -513,15 +512,20 @@ abstract class CoreModule
 
                     if ($field === 'effect')
                     {
-                        if (!$this->hidden_values_only)
+                        if ($this->privacy_model === PrivacyModel::Transparent)
                         {
                             if (!preg_match('/^-?\d+$/D', $value))
-                                throw new DeveloperError('`effect` is not a valid number');
+                                throw new DeveloperError("`effect` is not a valid number for `Transparent`: {$value}");
                         }
-                        else
+                        elseif ($this->privacy_model === PrivacyModel::Mixed)
+                        {
+                            if (!preg_match('/^-?\d+$/D', $value) && !in_array($value, ['-?', '+?']))
+                                throw new DeveloperError("`effect` is not a valid number for `Mixed`: {$value}");
+                        }
+                        else // Shielded
                         {
                             if (!in_array($value, ['-?', '+?']))
-                                throw new DeveloperError('`-?`, `+?` are the only variants for `effect` when `hidden_values_only` is true');
+                                throw new DeveloperError('`-?`, `+?` are the only variants for `effect` when `privacy_model` is `Shielded`');
                         }
                     }
 

--- a/Modules/Common/CryptoNoteMainModule.php
+++ b/Modules/Common/CryptoNoteMainModule.php
@@ -1,0 +1,246 @@
+<?php declare(strict_types = 1);
+
+/*  Idea (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
+ *  Distributed under the MIT software license, see LICENSE.md  */
+
+/*  This is a parser for Monero-like blockchains. It requires `moneroexamples/onion-monero-blockchain-explorer` as a node to
+ *  operate. `--enable-json-api` should be enabled.  */
+
+abstract class CryptoNoteMainModule extends CoreModule
+{
+    public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect'];
+    public ?array $events_table_nullable_fields = [];
+
+    public ?bool $should_return_events = true;
+    public ?bool $should_return_currencies = false;
+    public ?bool $allow_empty_return_events = false;
+
+    public ?bool $mempool_implemented = true;
+    public ?bool $forking_implemented = true;
+
+    public ?BlockHashFormat $block_hash_format = BlockHashFormat::HexWithout0x;
+    public ?AddressFormat $address_format = AddressFormat::AlphaNumeric; // There are two addresses only: `the-void` and `shielded-pool`
+    public ?TransactionHashFormat $transaction_hash_format = TransactionHashFormat::HexWithout0x;
+    public ?TransactionRenderModel $transaction_render_model = TransactionRenderModel::UTXO;
+    public ?CurrencyFormat $currency_format = CurrencyFormat::Static;
+    public ?CurrencyType $currency_type = CurrencyType::FT;
+    public ?FeeRenderModel $fee_render_model = FeeRenderModel::LastEventToTheVoid;
+    public ?array $special_addresses = ['the-void', 'shielded-pool'];
+
+    public ?PrivacyModel $privacy_model = PrivacyModel::Mixed; // Fees and coinbase rewards are visible for v2 transactions, the rest is not
+    public ?bool $ignore_sum_of_all_effects = true; // In mixed transactions we know fee values, but don't know input and output values
+
+    //
+
+    private ?array $block_data = null;
+
+    //
+
+    final public function pre_initialize()
+    {
+        $this->version = 1;
+    }
+
+    final public function post_post_initialize()
+    {
+
+    }
+
+    //
+
+    final public function inquire_latest_block()
+    {
+        return (int)requester_single($this->select_node(), 'api/networkinfo')['data']['height'] - 1; // For some reason,
+        // `height` returns a +1 value.
+    }
+
+    final public function ensure_block($block_id, $break_on_first = false)
+    {
+        if (count($this->nodes) === 1)
+        {
+            $this->block_data = requester_single($this->select_node(), "api/block/{$block_id}", result_in: 'data');
+        }
+        else
+        {
+            $multi_curl = [];
+
+            foreach ($this->nodes as $node)
+            {
+                $multi_curl[] = requester_multi_prepare($node, "api/block/{$block_id}", timeout: $this->timeout);
+                if ($break_on_first) break;
+            }
+
+            try
+            {
+                $curl_results = requester_multi($multi_curl, limit: count($this->nodes), timeout: $this->timeout);
+            }
+            catch (RequesterException $e)
+            {
+                throw new RequesterException("ensure_block(block_id: {$block_id}): no connection, previously: " . $e->getMessage());
+            }
+
+            $this->block_data = requester_multi_process($curl_results[0], result_in: 'data');
+            $first_hash = $this->block_data['hash'];
+
+            if (count($curl_results) > 1)
+            {
+                foreach ($curl_results as $result)
+                {
+                    if (requester_multi_process($result, result_in: 'data')['hash'] !== $first_hash)
+                    {
+                        throw new ConsensusException("ensure_block(block_id: {$block_id}): no consensus");
+                    }
+                }
+            }
+        }
+
+        if (!isset($this->block_data['hash']))
+            ddd($this->block_data);
+
+        $this->block_hash = $this->block_data['hash'];
+        $this->block_time = $this->block_data['timestamp_utc'];
+    }
+
+    final public function pre_process_block($block_id)
+    {
+        if ($block_id !== MEMPOOL)
+        {
+            if (is_null($this->block_data))
+                $this->ensure_block($block_id);
+        }
+        else // Processing mempool
+        {
+            $this->block_data = requester_single($this->select_node(),
+                endpoint: 'api/mempool',
+                timeout: $this->timeout,
+                result_in: 'data');
+        }
+
+        $multi_curl = [];
+
+        foreach ($this->block_data['txs'] as $tx)
+        {
+            if (!isset($this->processed_transactions[$tx['tx_hash']]))
+            {
+                $multi_curl[] = requester_multi_prepare(
+                    $this->select_node(),
+                    endpoint: "api/transaction/{$tx['tx_hash']}",
+                    timeout: $this->timeout
+                );
+            }
+        }
+
+        $multi_results = requester_multi_process_all(requester_multi($multi_curl,
+            limit: envm($this->module, 'REQUESTER_THREADS'),
+            timeout: $this->timeout),
+            result_in: 'data',
+            reorder: false);
+
+        $transaction_details = [];
+
+        foreach ($multi_results as $transaction)
+        {
+            $transaction_details[($transaction['tx_hash'])] = $transaction;
+        }
+
+        $events = []; // This is an array for the results
+        $sort_key = 1;
+        $coinbase_transactions = 0;
+
+        if (!$this->block_data['txs'][0]['coinbase'] && $block_id !== MEMPOOL)
+            throw new ModuleError('The first transaction is not coinbase');
+
+        if (count($this->block_data['txs']) !== count($transaction_details) && $block_id !== MEMPOOL)
+            throw new ModuleError('Transaction count mismatch');
+
+        foreach ($this->block_data['txs'] as $transaction)
+        {
+            if (isset($this->processed_transactions[$transaction['tx_hash']]))
+                continue;
+
+            if (!in_array($transaction['tx_version'], ['1', '2']))
+                throw new ModuleError('Unknown transaction version');
+
+            $hash = $transaction['tx_hash'];
+
+            if ($transaction['coinbase'])
+            {
+                $coinbase_transactions++;
+
+                if ($transaction['tx_fee'] !== '0')
+                    throw new ModuleError('The coinbase transaction fee is not 0');
+
+                $total_coinbase = '0';
+
+                foreach ($transaction_details[$hash]['outputs'] as $output)
+                {
+                    if ($output['amount'] === '0')
+                        throw new ModuleError('Zero coinbase output'); // That'd cause undefined behaviour as
+                    // `tx_version` can be both `1` and `2` for transparent coinbase transactions, and we won't have
+                    // a way to differ +0 from +?
+
+                    $events[] = ['transaction' => $hash,
+                                 'address'     => 'shielded-pool',
+                                 'effect'      => $output['amount'],
+                                 'sort_key'    => $sort_key++,
+                    ];
+
+                    $total_coinbase = bcadd($total_coinbase, $output['amount']);
+                }
+
+                $events[] = ['transaction' => $hash,
+                             'address'     => 'the-void',
+                             'effect'      => '-' . $total_coinbase,
+                             'sort_key'    => 0,
+                ];
+            }
+            else
+            {
+                foreach ($transaction_details[$hash]['inputs'] as $input)
+                {
+                    $amount = ($transaction['tx_version'] === '1') ? '-' . $input['amount'] : '-?';
+                    // In Monero, 1220516 is the latest block with visible transaction amounts
+
+                    $events[] = ['transaction' => $hash,
+                                 'address'     => 'shielded-pool',
+                                 'effect'      => $amount,
+                                 'sort_key'    => $sort_key++,
+                    ];
+                }
+
+                foreach ($transaction_details[$hash]['outputs'] as $output)
+                {
+                    $amount = ($transaction['tx_version'] === '1') ? $output['amount'] : '+?';
+
+                    $events[] = ['transaction' => $hash,
+                                 'address'     => 'shielded-pool',
+                                 'effect'      => $amount,
+                                 'sort_key'    => $sort_key++,
+                    ];
+                }
+
+                $events[] = ['transaction' => $hash,
+                             'address'     => 'the-void',
+                             'effect'      => $transaction['tx_fee'],
+                             'sort_key'    => $sort_key++,
+                ];
+            }
+        }
+
+        if ($coinbase_transactions !== 1 && $block_id !== MEMPOOL)
+            throw new ModuleError('Wrong number of coinbase transactions');
+
+        foreach ($events as &$event)
+        {
+            $event['block'] = $block_id;
+            $event['time'] = ($this->block_id !== MEMPOOL) ? $this->block_time : date('Y-m-d H:i:s', time());
+        }
+
+        usort($events, function($a, $b) {
+            return $a['sort_key'] <=> $b['sort_key'];
+        });
+
+        $this->set_return_events($events);
+    }
+}

--- a/Modules/Common/EVMERC1155Module.php
+++ b/Modules/Common/EVMERC1155Module.php
@@ -18,7 +18,7 @@ abstract class EVMERC1155Module extends CoreModule
     public ?CurrencyFormat $currency_format = CurrencyFormat::HexWith0x;
     public ?CurrencyType $currency_type = CurrencyType::MT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'currency', 'address', 'effect', 'extra'];
     public ?array $events_table_nullable_fields = [];

--- a/Modules/Common/EVMERC20Module.php
+++ b/Modules/Common/EVMERC20Module.php
@@ -18,7 +18,7 @@ abstract class EVMERC20Module extends CoreModule
     public ?CurrencyFormat $currency_format = CurrencyFormat::HexWith0x;
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'currency', 'address', 'effect'];
     public ?array $events_table_nullable_fields = [];

--- a/Modules/Common/EVMERC721Module.php
+++ b/Modules/Common/EVMERC721Module.php
@@ -18,7 +18,7 @@ abstract class EVMERC721Module extends CoreModule
     public ?CurrencyFormat $currency_format = CurrencyFormat::HexWith0x;
     public ?CurrencyType $currency_type = CurrencyType::NFT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'currency', 'address', 'effect', 'extra'];
     public ?array $events_table_nullable_fields = [];

--- a/Modules/Common/EVMMainModule.php
+++ b/Modules/Common/EVMMainModule.php
@@ -19,7 +19,7 @@ abstract class EVMMainModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::ExtraBF;
     public ?array $special_addresses = ['the-void'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect', 'failed', 'extra'];
     public ?array $events_table_nullable_fields = ['transaction', 'extra'];

--- a/Modules/Common/EVMTraceModule.php
+++ b/Modules/Common/EVMTraceModule.php
@@ -15,7 +15,7 @@ abstract class EVMTraceModule extends CoreModule
     public ?TransactionHashFormat $transaction_hash_format = TransactionHashFormat::HexWith0x;
     public ?TransactionRenderModel $transaction_render_model = TransactionRenderModel::Even;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect', 'extra'];
     public ?array $events_table_nullable_fields = ['extra'];

--- a/Modules/Common/HandshakeLikeMainModule.php
+++ b/Modules/Common/HandshakeLikeMainModule.php
@@ -20,7 +20,7 @@ abstract class HandshakeLikeMainModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::LastEventToTheVoid;
     public ?array $special_addresses = ['the-void'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect', 'extra', 'extra_indexed'];
     public ?array $events_table_nullable_fields = ['extra', 'extra_indexed'];

--- a/Modules/Common/MimbleWimbleModule.php
+++ b/Modules/Common/MimbleWimbleModule.php
@@ -50,7 +50,7 @@ abstract class MimbleWimbleModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
 
-    public ?bool $hidden_values_only = true; // We don't know transfer amounts in MWEB!
+    public ?PrivacyModel $privacy_model = PrivacyModel::Shielded; // We don't know transfer amounts in MWEB!
 
     //
 

--- a/Modules/Common/TONLikeMainModule.php
+++ b/Modules/Common/TONLikeMainModule.php
@@ -16,7 +16,7 @@ abstract class TONLikeMainModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::ExtraF;
     public ?array $special_addresses = ['the-void'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect', 'extra'];
     public ?array $events_table_nullable_fields = ['extra'];

--- a/Modules/Common/UTXODIP2Module.php
+++ b/Modules/Common/UTXODIP2Module.php
@@ -31,7 +31,7 @@ abstract class UTXODIP2Module extends CoreModule
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
     public ?array $special_addresses = ['*-tx'];
 
-    public ?bool $hidden_values_only = true; // There's nothing really being transferred
+    public ?PrivacyModel $privacy_model = PrivacyModel::Shielded; // There's nothing really being transferred
 
     //
 

--- a/Modules/Common/UTXOFCTModule.php
+++ b/Modules/Common/UTXOFCTModule.php
@@ -34,7 +34,7 @@ abstract class UTXOFCTModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
     public ?array $special_addresses = ['the-void', 'script-*'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     //
 

--- a/Modules/Common/UTXOMainModule.php
+++ b/Modules/Common/UTXOMainModule.php
@@ -18,7 +18,7 @@ abstract class UTXOMainModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::LastEventToTheVoid;
     public ?array $special_addresses = ['the-void', 'script-*'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent; // This also includes Zcash as we show value changes for the shielded pools
 
     public ?array $events_table_fields = ['block', 'transaction', 'sort_key', 'time', 'address', 'effect'];
     public ?array $events_table_nullable_fields = [];

--- a/Modules/Common/UTXONFCTModule.php
+++ b/Modules/Common/UTXONFCTModule.php
@@ -36,7 +36,7 @@ abstract class UTXONFCTModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::NFT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
     public ?array $special_addresses = ['the-void', 'script-*'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     //
 

--- a/Modules/Common/UTXOOmniModule.php
+++ b/Modules/Common/UTXOOmniModule.php
@@ -113,7 +113,7 @@ abstract class UTXOOmniModule extends CoreModule
     public ?CurrencyType $currency_type = CurrencyType::FT;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
     public ?array $special_addresses = ['the-void'];
-    public ?bool $hidden_values_only = false;
+    public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
     public ?int $genesis_block = null;
     public ?string $genesis_json = null;

--- a/Modules/MoneroMainModule.php
+++ b/Modules/MoneroMainModule.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+/*  Idea (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
+ *  Distributed under the MIT software license, see LICENSE.md  */
+
+/*  This module processes Monero transactions. See `CryptoNoteMainModule.php` for details.  */
+
+final class MoneroMainModule extends CryptoNoteMainModule implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'monero';
+        $this->module = 'monero-main';
+        $this->is_main = true;
+        $this->currency = 'monero';
+        $this->currency_details = ['name' => 'Monero', 'symbol' => 'XMR', 'decimals' => 12, 'description' => null];
+        $this->first_block_id = 0;
+        $this->first_block_date = '2014-04-18';
+    }
+}


### PR DESCRIPTION
This PR proposes

1) Adding `PrivacyModel` class and a `privacy_model` setting instead of the `hidden_values_only`
2) Adding Monero support