### PR TITLE
Add Groestlcoin support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1051,3 +1051,21 @@ MODULE_monero-main_NODES[]=http://login:password@127.0.0.1:1234/
 MODULE_monero-main_NODES[]=http://login:password@127.0.0.2:1234/
 MODULE_monero-main_REQUESTER_TIMEOUT=60
 MODULE_monero-main_REQUESTER_THREADS=12
+
+###############
+# Groestlcoin #
+###############
+
+FRONT_groestlcoin_ECOSYSTEM_TITLE=Groestlcoin Ecosystem
+FRONT_groestlcoin_ECOSYSTEM_DESCRIPTION=Includes Groestlcoin only
+FRONT_groestlcoin_BLOCKCHAIN_TITLE=Groestlcoin
+FRONT_groestlcoin_BLOCKCHAIN_DESCRIPTION=A cryptocurrency with the unique Groestl hash algorithm, offering low fees and a focus on privacy.
+FRONT_groestlcoin-main_MODULE_TITLE=Main
+FRONT_groestlcoin-main_MODULE_DESCRIPTION=Main Groestlcoin transfers
+
+MODULES[]=groestlcoin-main
+MODULE_groestlcoin-main_CLASS=GroestlcoinMainModule
+MODULE_groestlcoin-main_NODES[]=http://login:password@127.0.0.1:1234/
+MODULE_groestlcoin-main_NODES[]=http://login:password@127.0.0.2:1234/
+MODULE_groestlcoin-main_REQUESTER_TIMEOUT=60
+MODULE_groestlcoin-main_REQUESTER_THREADS=12

--- a/Modules/GroestlcoinMainModule.php
+++ b/Modules/GroestlcoinMainModule.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+/*  Idea (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
+ *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
+ *  Distributed under the MIT software license, see LICENSE.md  */
+
+/*  This is the main Groestlcoin module. It requires Grostlcoin Core (https://github.com/Groestlcoin/groestlcoin)
+ *  with `txindex` set to true to run. Note that for correct processing of P2PK outputs this should be reverted:
+ *  https://github.com/bitcoin/bitcoin/pull/16725/files and the ExtractDestination() function itself should return
+ *  `true` for `PUBKEY` like this: ```CPubKey pubKey(vSolutions[0]); if (!pubKey.IsValid()) return false;
+ *  addressRet = PKHash(pubKey); return true;```  */
+
+final class GroestlcoinMainModule extends UTXOMainModule implements Module
+{
+    function initialize()
+    {
+        // CoreModule
+        $this->blockchain = 'groestlcoin';
+        $this->module = 'groestlcoin-main';
+        $this->is_main = true;
+        $this->currency = 'groestlcoin'; // Static
+        $this->currency_details = ['name' => 'Groestlcoin', 'symbol' => 'GRS', 'decimals' => 8, 'description' => null];
+        $this->first_block_date = '2014-03-20';
+
+        // UTXOMainModule
+        $this->extra_features = [UTXOSpecialFeatures::OneAddressInScriptPubKey, UTXOSpecialFeatures::IgnorePubKeyConversion];
+        $this->p2pk_prefix1 = '';
+        $this->p2pk_prefix2 = '24';
+    }
+}


### PR DESCRIPTION
This PR proposes adding Groestlcoin to 3xpl.

Please note that currently it's required to tweak a node to produce P2PK addresses as PHP doesn't have native support for the Grøstl hash function, therefore we can't use the `CryptoP2PK` class for the pubkey to address conversion.