### PR TITLE
Add 3DNS support

### DIFF
--- a/Modules/OptimismMainModule.php
+++ b/Modules/OptimismMainModule.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types = 1);
 
 /*  Idea (c) 2023 Nikita Zhavoronkov, nikzh@nikzh.com
- *  Copyright (c) 2023 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
+ *  Copyright (c) 2023-2024 3xpl developers, 3@3xpl.com, see CONTRIBUTORS.md
  *  Distributed under the MIT software license, see LICENSE.md  */
 
 /*  This is the main Optimism module. It requires a geth node to run.  */
@@ -30,7 +30,8 @@ final class OptimismMainModule extends EVMMainModule implements Module
 
         // Handles
         $this->handles_implemented = true;
-        $this->handles_regex = '/(.*)\.box/';
+        // This is the full list of names supported by 3DNS, including .box
+        $this->handles_regex = '/(.*)\.(box|ac|academy|accountant|accountants|actor|agency|ai|airforce|apartments|app|archi|army|art|asia|associates|at|attorney|auction|audio|auto|autos|baby|band|bar|bargains|bayern|beauty|beer|best|bible|bid|bike|bingo|bio|biz|black|blackfriday|blog|blue|boats|bond|boston|boutique|builders|business|buzz|ca|cab|cafe|cam|camera|camp|capital|car|cards|care|careers|cars|casa|cash|casino|catering|cc|center|cfd|charity|chat|cheap|christmas|church|city|claims|cleaning|click|clinic|clothing|cloud|club|co|coach|codes|coffee|college|com|community|company|computer|condos|construction|consulting|contact|contractors|cooking|cool|coupons|courses|credit|creditcard|cricket|cruises|cyou|dance|date|dating|de|dealer|deals|degree|delivery|democrat|dental|dentist|design|dev|diamonds|diet|digital|direct|directory|discount|doctor|dog|domains|download|earth|education|email|energy|engineer|engineering|enterprises|equipment|estate|eu|events|exchange|expert|exposed|express|fail|faith|family|fans|farm|fashion|feedback|film|finance|financial|fish|fishing|fit|fitness|flights|florist|flowers|football|forsale|foundation|fun|fund|furniture|futbol|fyi|gallery|game|games|garden|gay|gift|gifts|gives|glass|global|gmbh|gold|golf|graphics|gratis|green|gripe|group|guide|guitars|guru|hair|haus|health|healthcare|help|hiphop|hiv|hockey|holdings|holiday|homes|horse|hospital|host|hosting|house|icu|immo|immobilien|in|inc|industries|info|ink|institute|insure|international|investments|io|irish|ist|istanbul|jetzt|jewelry|juegos|kaufen|kids|kim|kitchen|la|land|lat|law|lawyer|lease|legal|lgbt|life|lighting|limited|limo|link|live|llc|loan|loans|lol|london|love|ltd|luxe|maison|makeup|management|market|marketing|mba|me|media|melbourne|memorial|men|menu|miami|mobi|moda|moe|mom|money|monster|mortgage|motorcycles|movie|mx|navy|net|network|news|ninja|nl|nyc|observer|one|online|ooo|org|organic|page|partners|parts|party|pet|ph|photo|photography|photos|pics|pictures|pink|pizza|place|plumbing|plus|poker|press|pro|productions|promo|properties|property|protection|pub|pw|quest|racing|realty|recipes|red|rehab|reise|reisen|rent|rentals|repair|report|republican|rest|restaurant|review|reviews|rip|rocks|rodeo|run|sale|salon|sarl|sbs|school|schule|science|security|services|sexy|sh|shiksha|shoes|shop|shopping|show|singles|site|ski|skin|soccer|social|software|solar|solutions|space|storage|store|stream|studio|study|style|sucks|supplies|supply|support|surf|surgery|sydney|systems|tattoo|tax|taxi|team|tech|technology|tel|tennis|theater|theatre|tickets|tienda|tips|tires|today|tools|top|tours|town|toys|trade|training|travel|tube|tv|uk|university|uno|us|vacations|vegas|ventures|vet|viajes|video|villas|vin|vip|vision|vodka|vote|voyage|watch|webcam|website|wedding|whoswho|wiki|win|wine|work|works|world|ws|wtf|xyz|yachts|yoga|zone)/';
         $this->api_get_handle = function($handle)
         {
             if (!preg_match($this->handles_regex, $handle))
@@ -43,9 +44,10 @@ final class OptimismMainModule extends EVMMainModule implements Module
             if (is_null($hash) || $hash === '')
                 return null;
 
+            // First, we look for forward resolution
             $address = $this->ens_get_data_from_resolver('0xf97aac6c8dbaebcb54ff166d79706e3af7a813c8', $hash, '0x3b3b57de', -40);
 
-            if ($address === '0000000000000000000000000000000000000000') // try to call ownerOf on .box NFT contract
+            if ($address === '0000000000000000000000000000000000000000') // Then, if nothing has been found, we look for the owner (ownerOf)
                 $address = $this->ens_get_data_from_resolver('0xbb7b805b257d7c76ca9435b3ffe780355e4c4b17', $hash, '0x6352211e', -40);
 
             if ($address && $address !== '0000000000000000000000000000000000000000')


### PR DESCRIPTION
As it turns out, the same contract which processes .box names (#76), also processes all names supported by 3DNS. This PR proposes adding them to 3xpl.

References: https://3dns.box/, https://opensea.io/collection/3dns-powered-domains