### PR TITLE
fix transaction ordering

### DIFF
--- a/Modules/Common/BeaconChainLikeAttestationsModule.php
+++ b/Modules/Common/BeaconChainLikeAttestationsModule.php
@@ -13,8 +13,8 @@ abstract class BeaconChainLikeAttestationsModule extends CoreModule
 
     public ?BlockHashFormat $block_hash_format = BlockHashFormat::HexWithout0x;
     public ?AddressFormat $address_format = AddressFormat::AlphaNumeric;
-    public ?TransactionHashFormat $transaction_hash_format = TransactionHashFormat::None;
-    public ?TransactionRenderModel $transaction_render_model = TransactionRenderModel::None;
+    public ?TransactionHashFormat $transaction_hash_format = TransactionHashFormat::AlphaNumeric;
+    public ?TransactionRenderModel $transaction_render_model = TransactionRenderModel::Mixed;
     public ?FeeRenderModel $fee_render_model = FeeRenderModel::None;
     public ?PrivacyModel $privacy_model = PrivacyModel::Transparent;
 
@@ -186,12 +186,18 @@ abstract class BeaconChainLikeAttestationsModule extends CoreModule
         {
             $events[] = [
                 'block' => $block,
-                'sort_key' => $key_tes++,
                 'time' => $this->block_time,
                 'address' => (string)$validator,
                 'effect' => $reward,
             ];
         }
+
+        usort($events, function ($a, $b) {
+            return (strcmp($a['address'], $b['address']));
+        });
+
+        foreach($events as &$ev)
+            $ev['sort_key'] = $key_tes++;
 
         $this->set_return_events($events);
     }

--- a/Modules/Common/BeaconChainLikeDepositsModule.php
+++ b/Modules/Common/BeaconChainLikeDepositsModule.php
@@ -155,6 +155,8 @@ abstract class BeaconChainLikeDepositsModule extends CoreModule
                     ];
                 }
             }
+            $this->set_return_events($events);
+            return;
         }
 
         foreach ($deposits as [$index, $address, $amount, $slot, $deposit_address])
@@ -162,13 +164,19 @@ abstract class BeaconChainLikeDepositsModule extends CoreModule
             $events[] = [
                 'block' => $block,
                 'transaction' => $slot,
-                'sort_key' => $key_tes++,
                 'time' => $this->block_time,
                 'address' => (string)$index,
                 'effect' => $amount,
                 'extra_indexed' => (string)$deposit_address
             ];
         }
+
+        usort($events, function ($a, $b) {
+            return (strcmp($a['transaction'], $b['transaction']));
+        });
+
+        foreach($events as &$ev)
+            $ev['sort_key'] = $key_tes++;
 
         $this->set_return_events($events);
     }

--- a/Modules/Common/BeaconChainLikePenaltiesModule.php
+++ b/Modules/Common/BeaconChainLikePenaltiesModule.php
@@ -171,6 +171,14 @@ abstract class BeaconChainLikePenaltiesModule extends CoreModule
             }
         }
 
+        usort($proposers_slashing, function ($a, $b) {
+            return (strcmp($a[1], $b[1]));
+        });
+
+        usort($attestors_slashing, function ($a, $b) {
+            return (strcmp($a[1], $b[1]));
+        });
+
         $this->get_epoch_time($block, $slots);
 
         foreach ($slots as $slot => $tm)

--- a/Modules/Common/BeaconChainLikeProposalsModule.php
+++ b/Modules/Common/BeaconChainLikeProposalsModule.php
@@ -123,6 +123,7 @@ abstract class BeaconChainLikeProposalsModule extends CoreModule
         }
 
         $key_tes = 0;
+        ksort($rewards_slots);
 
         foreach ($rewards_slots as $slot => [$validator, $reward])
         {

--- a/Modules/Common/BeaconChainLikeWithdrawalsModule.php
+++ b/Modules/Common/BeaconChainLikeWithdrawalsModule.php
@@ -115,6 +115,10 @@ abstract class BeaconChainLikeWithdrawalsModule extends CoreModule
             }
         }
 
+        usort($withdrawals, function ($a, $b) {
+            return (strcmp($a[3], $b[3]));
+        });
+
         $this->get_epoch_time($block, $slots);
         $key_tes = 0;
 


### PR DESCRIPTION
In this PR, there are some fixes to address event ordering issues. The primary problem was that multicurl doesn't inherently guarantee order, which led to data corruption (the same block could return events in different sequences). This issue has been resolved in the affected modules.
For more details on the original problem, please refer to the following [issue](https://github.com/3xplcom/Core/issues/74).